### PR TITLE
Added one line to README.md to fix the installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ also build `lucida-suite` and `lucida`.
 export THRIFT_ROOT=`pwd`/tools/thrift-0.9.2
 export CAFFE=`pwd`/tools/caffe/distribute
 export LUCIDAROOT=`pwd`/lucida
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 ```
 - Start all the services using supervisord:
 ```


### PR DESCRIPTION
Added one line in `README.md` to include `/usr/local/lib` to `$LD_LIBRARY_PATH` to smooth the installation process. Without this setting, users could encounter errors like `while loading shared libraries: libopencv_core.so.2.4: cannot open shared object file: No such file or directory` while building imagematching server.