### PR TITLE
Allows longer email addresses

### DIFF
--- a/lucida/commandcenter/controllers/RegistrationForm.py
+++ b/lucida/commandcenter/controllers/RegistrationForm.py
@@ -61,6 +61,6 @@ class RegistrationForm(Form):
 
 	email = TextField('Email Address', 
 					  [validators.Length(
-					  max=20,
-					  message=too_long_error_msg('Email', 20)),
+					  max=255,
+					  message=too_long_error_msg('Email', 255)),
 					  email_check])


### PR DESCRIPTION
As pointed by Mason Hill in [Slack's channel #dev](https://lucida-ai.slack.com/archives/C0TNQV0R5/p1494945702836559), the email address limit needs to be longer. 

`20` characters couldn't fit most of the email addresses.

Setting to `255` characters.